### PR TITLE
Allow customizer for test

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -22,6 +22,7 @@ type GeoPoint interface {
 	GetCoordinates() GeoCoordinates
 }
 
+// If you want to customize the algorithm, for example to track the points that clusterized you should provide this type
 type ClusterCustomizer interface {
 	GeoPoint2ClusterPoint(point GeoPoint) ClusterPoint
 	AggregateClusterPoints(point ClusterPoint, aggregated []ClusterPoint, zoom int) ClusterPoint
@@ -150,6 +151,8 @@ func NewCluster() *Cluster {
 	}
 }
 
+// Create new Cluster with given customizer and default parameters
+// Same as NewCluster but allows changing the clustering result
 func NewClusterFromCustomizer (customizer ClusterCustomizer) *Cluster {
 	return &Cluster{
 		MinZoom:   0,

--- a/cluster_customized_test.go
+++ b/cluster_customized_test.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type testClusterPoint struct {
+	X,Y float64
+	zoom int
+	Id int //Index for pint, Id for cluster
+	NumPoints int
+	aggregatedClusters []testClusterPoint
+}
+
+func TestCluster_Customizer (t *testing.T) {
+	points := importData("./testdata/places.json")
+	geoPoints := make([]GeoPoint, len(points))
+	for i := range points {
+		geoPoints[i] = points[i]
+	}
+
+	customizer := testCustomizer{}
+
+	c := NewClusterFromCustomizer(customizer)
+	c.ClusterPoints(geoPoints)
+
+	northWest := simplePoint{71.36718750000001, -83.79204408779539}
+	southEast := simplePoint{-71.01562500000001, 83.7539108491127}
+
+	var result []ClusterPoint = c.GetClusters(northWest, southEast, 2)
+	for _, p := range(result) {
+		assert.Equal(t, len(p.(testClusterPoint).aggregatedClusters), p.getNumPoints() - 1, "We get all points except itself")
+	}
+}
+
+
+func (cp testClusterPoint)	Coordinates() (float64, float64) {
+	return cp.X, cp.Y
+}
+
+func (cp testClusterPoint) getX() float64 {
+	return cp.X
+}
+
+func (cp testClusterPoint) getY() float64 {
+	return cp.Y
+}
+
+func (cp testClusterPoint) setX(x float64) ClusterPoint {
+	cp.X = x
+	return cp
+}
+
+func (cp testClusterPoint) setY(y float64) ClusterPoint {
+	cp.Y = y
+	return cp
+}
+
+func (cp testClusterPoint) setZoom(zoom int) ClusterPoint {
+	cp.zoom = zoom
+	return cp
+}
+func (cp testClusterPoint) getZoom() int{
+	return cp.zoom
+}
+
+func (cp testClusterPoint) setNumPoints(numPoints int) ClusterPoint {
+	cp.NumPoints = numPoints
+	return cp
+}
+func (cp testClusterPoint) getNumPoints() int{
+	return cp.NumPoints
+}
+func (cp testClusterPoint) setId(id int) ClusterPoint {
+	cp.Id = id
+	return cp
+}
+
+type testCustomizer struct {
+
+}
+func (dc testCustomizer) GeoPoint2ClusterPoint(point GeoPoint) ClusterPoint {
+	cp := testClusterPoint{aggregatedClusters: make([]testClusterPoint, 0, 10)}
+	return cp
+}
+
+func (dc testCustomizer) AggregateClusterPoints(point ClusterPoint, aggregated []ClusterPoint, zoom int) ClusterPoint {
+	cp := point.(testClusterPoint)
+	if (cap(cp.aggregatedClusters) < len(cp.aggregatedClusters) + len(aggregated)) {
+		newAggregated := make([]testClusterPoint, len(cp.aggregatedClusters), max(len(cp.aggregatedClusters) + len(aggregated), 2 * cap(cp.aggregatedClusters)))
+		copy(cp.aggregatedClusters, newAggregated)
+		cp.aggregatedClusters = newAggregated
+	}
+
+	for _, p := range(aggregated) {
+		testPoint := p.(testClusterPoint)
+		if (cap(cp.aggregatedClusters) < len(cp.aggregatedClusters) + 1 + len(testPoint.aggregatedClusters)) {
+			newAggregated := make([]testClusterPoint, len(cp.aggregatedClusters), max(len(cp.aggregatedClusters) + 1 + len(testPoint.aggregatedClusters), 2 * cap(cp.aggregatedClusters)))
+			cp.aggregatedClusters = newAggregated
+		}
+		cp.aggregatedClusters = append(cp.aggregatedClusters, testPoint.aggregatedClusters...)
+		cp.aggregatedClusters = append(cp.aggregatedClusters, testPoint)
+	}
+	return cp
+}
+
+func max (a, b int) int {
+	if (a > b) {
+		return a
+	}
+	return b
+}
+
+
+func importData(filename string) []*TestPoint {
+	var points = struct {
+		Type     string
+		Features []*TestPoint
+	}{}
+	raw, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
+	json.Unmarshal(raw, &points)
+	//fmt.Printf("Gett data: %+v\n",points)
+	return points.Features
+}
+////Helpers
+type simplePoint struct {
+	Lon, Lat float64
+}
+
+func (sp simplePoint) GetCoordinates() GeoCoordinates {
+	return GeoCoordinates{sp.Lon, sp.Lat}
+}
+type TestPoint struct {
+	Type       string
+	Properties struct {
+		//we don't need other data
+		Name       string
+		PointCount int `json:"point_count"`
+	}
+	Geometry struct {
+		Coordinates []float64
+	}
+}
+
+func (tp *TestPoint) GetCoordinates() GeoCoordinates {
+	return GeoCoordinates{
+		Lon: tp.Geometry.Coordinates[0],
+		Lat: tp.Geometry.Coordinates[1],
+	}
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -47,7 +47,7 @@ func TestCluster_GetTile00(t *testing.T) {
 	assert.NotEmpty(t, result)
 
 	expectedPoints := importPoints("./testdata/expect_tile0_0_0.json")
-	assert.Equal(t, result, expectedPoints)
+	assert.Equal(t, expectedPoints, result)
 }
 
 //validate original result from JS library
@@ -73,10 +73,10 @@ func TestCluster_GetTileDefault(t *testing.T) {
 	for i := range result {
 		rp := result[i]
 		ep := expectedPoints[i]
-		assert.Equal(t, rp.X, ep.Geometry[0][0])
-		assert.Equal(t, rp.Y, ep.Geometry[0][1])
-		if rp.NumPoints > 1 {
-			assert.Equal(t, rp.NumPoints, ep.Tags.PointCount)
+		assert.Equal(t, rp.getX(), ep.Geometry[0][0])
+		assert.Equal(t, rp.getY(), ep.Geometry[0][1])
+		if rp.getNumPoints() > 1 {
+			assert.Equal(t, rp.getNumPoints(), ep.Tags.PointCount)
 		}
 
 	}
@@ -112,12 +112,14 @@ func TestCluster_GetClusters(t *testing.T) {
 	for i := range result {
 		rp := result[i]
 		ep := expectedPoints[i]
-		assert.True(t, floatEquals(rp.X, ep.Geometry.Coordinates[0]))
-		assert.True(t, floatEquals(rp.Y, ep.Geometry.Coordinates[1]))
-		if rp.NumPoints > 1 {
-			assert.Equal(t, rp.NumPoints, ep.Properties.PointCount)
-		}
 
+		t.Logf("Zoom", rp.getZoom())
+		t.Logf("Coordinates are:", rp.getX(), ep.Geometry.Coordinates[0])
+		assert.True(t, floatEquals(rp.getX(), ep.Geometry.Coordinates[0]))
+		assert.True(t, floatEquals(rp.getY(), ep.Geometry.Coordinates[1]))
+		if rp.getNumPoints() > 1 {
+			assert.Equal(t, rp.getNumPoints(), ep.Properties.PointCount)
+		}
 	}
 
 	//resultJSON, _ :=  json.MarshalIndent(result,"","    ")
@@ -209,7 +211,7 @@ func ExampleCluster_GetClusters() {
 
 	var result []ClusterPoint = c.GetClusters(northWest, southEast, 2)
 	fmt.Printf("%+v",result[:3])
-	// Output: [{X:-14.473194953510028 Y:26.157965399212813 zoom:1 Id:107 NumPoints:1} {X:-12.408741828510014 Y:58.16339752811905 zoom:1 Id:159 NumPoints:1} {X:-9.269962828651519 Y:42.928736057812586 zoom:1 Id:127 NumPoints:1}]
+	// Output: [{X:-14.473194953510028 Y:26.157965399212813 zoom:2 Id:107 NumPoints:1} {X:-12.408741828510014 Y:58.16339752811905 zoom:2 Id:159 NumPoints:1} {X:-9.269962828651519 Y:42.928736057812586 zoom:2 Id:127 NumPoints:1}]
 }
 
 ////Helpers
@@ -263,15 +265,18 @@ func importData(filename string) []*TestPoint {
 }
 
 func importPoints(filename string) []ClusterPoint {
-	var result []ClusterPoint
+	var loaded []clusterPoint
 	raw, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Println(err.Error())
 		return nil
 	}
-	json.Unmarshal(raw, &result)
+	json.Unmarshal(raw, &loaded)
+	result := make([]ClusterPoint, len(loaded))
+	for i, d := range loaded {
+		result[i] = d
+	}
 	return result
-
 }
 
 func importGeoJSONResultFeature(filename string) []GeoJSONResultFeature {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,13 +1,15 @@
 package cluster
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"encoding/json"
 )
+
+
 
 func TestNewCluster(t *testing.T) {
 	points := importData("./testdata/places.json")
@@ -213,6 +215,8 @@ func ExampleCluster_GetClusters() {
 	fmt.Printf("%+v",result[:3])
 	// Output: [{X:-14.473194953510028 Y:26.157965399212813 zoom:2 Id:107 NumPoints:1} {X:-12.408741828510014 Y:58.16339752811905 zoom:2 Id:159 NumPoints:1} {X:-9.269962828651519 Y:42.928736057812586 zoom:2 Id:127 NumPoints:1}]
 }
+
+
 
 ////Helpers
 type simplePoint struct {


### PR DESCRIPTION
Basically this pr allows to customize the aggregation. For example tracking the points that are aggregated (there was a todo for this, I've added a test).

I don't know much golang, so it is possible that some are the default way to do it. Feel free to point them out and I'll try to fix them. For example, there were a couple of test utils that I duplicated, I suppose there should be a better way.